### PR TITLE
Feat: Manage lambdas on AWS using AWS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,14 @@ And finally we can call it:
 > aws lambda invoke --profile sbox --function-name foo-lambda --cli-binary-format raw-in-base64-out --payload '{ "key": "value" }' /dev/stdout
 
 
-{"statusCode":200,"body":"{\"hello\":\"Hello from Lambda!\"}"}
+{"statusCode":200,"body":"{\"hello\":\"Hello from Lambda!\",\"inputEvent\":{\"key\":\"value\"}}"}
     "StatusCode": 200,
     "ExecutedVersion": "$LATEST"
 }
+```
+
+The function's code can be updating using the following command:
+
+```sh
+aws lambda update-function-code --profile sbox --function-name foo-lambda  --zip-file fileb://lambdas/foo-lambda/lambda.zip
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Work in progress...
 ## Prerequisites
 
 - [nvm](https://github.com/nvm-sh/nvm) - Node Version Manager.
+- Basic Unix commands are in place: [zip](https://infozip.sourceforge.net/Zip.html), `rm`.
 
 
 ## Runtime and dependencies
@@ -65,4 +66,48 @@ Packages: -1
 Done in 135ms using pnpm v10.11.1
 
 *** Done, please manually commit the changes now!
+```
+
+## Managing lambdas with AWS CLI
+
+This section describes how to use AWS CLI v2 to deploy and manage a locally created lambda to AWS. We will be using a separate AWS CLI settings profile that's called `sbox` in all the commands below. Please make sure that the following prerequisites are met:
+
+- [AWS CLI V2 is installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- [Settings for the AWS CLI are configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)(LTLR: `aws configure --profile sbox`)
+
+Let's create and build a lambda using this repo commands first:
+
+```sh
+pnpm lambda:create foo-lambda && pnpm --filter foo-lambda build
+```
+
+Then we're going to need a very basic role for our lambda functions:
+
+```sh
+aws iam create-role --profile sbox --role-name basic-lambda-role --assume-role-policy-document '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "Service": "lambda.amazonaws.com" }, "Action": "sts:AssumeRole" } ] }'
+```
+
+By the way, many of the AWS CLI commands could be reversed redone by using their counterparts:
+
+```sh
+aws iam delete-role --profile sbox --role-name basic-lambda-role
+```
+
+Now we can deploy the function:
+
+```sh
+# BASIC_LAMBDA_ROLE_ARN has to be set to an ARN of the role that was create above
+aws lambda create-function --profile sbox --function-name foo-lambda --runtime nodejs22.x --zip-file fileb://lambdas/foo-lambda/lambda.zip --handler index.handler --role "$BASIC_LAMBDA_ROLE_ARN"
+```
+
+And finally we can call it:
+
+```sh
+> aws lambda invoke --profile sbox --function-name foo-lambda --cli-binary-format raw-in-base64-out --payload '{ "key": "value" }' /dev/stdout
+
+
+{"statusCode":200,"body":"{\"hello\":\"Hello from Lambda!\"}"}
+    "StatusCode": 200,
+    "ExecutedVersion": "$LATEST"
+}
 ```

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ export AWS_PROFILE="sbox"
 
 Before getting started, please make sure that the following prerequisites are met:
 
-- [AWS CLI V2 is installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-- [Settings for the AWS CLI are configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)(LTLR: `aws configure`)
+- [AWS CLI V2 is installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)(TLTR: `brew install awscli`)
+- [Settings for the AWS CLI are configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)(TLTR: `aws configure`)
 
 Let's create and build a lambda using this repo commands first:
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "",
   "scripts": {
     "lambda:create": "packages/monorepo-utils/bin/create.mjs templates/lambda lambdas",
-    "lambda:remove": "packages/monorepo-utils/bin/remove.mjs lambdas",
+    "lambda:delete": "packages/monorepo-utils/bin/remove.mjs lambdas",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": ["nodejs", "typescript"],

--- a/packages/monorepo-utils/bin/remove.mjs
+++ b/packages/monorepo-utils/bin/remove.mjs
@@ -7,7 +7,7 @@ import { parseArgs } from 'node:util';
 
 const USAGE = (
   'USAGE: remove.mjs PROJECT_DIR PROJECT_NAME\n' +
-  '       lambda:remove PROJECT_NAME'
+  '       lambda:delete PROJECT_NAME'
 );
 
 async function main() {

--- a/templates/lambda/index.mjs
+++ b/templates/lambda/index.mjs
@@ -2,7 +2,10 @@ export const handler = async (event) => {
   console.log('Event: ', JSON.stringify(event, null, 2));
   const response = {
     statusCode: 200,
-    body: JSON.stringify({ hello: 'Hello from Lambda!' }),
+    body: JSON.stringify({
+      hello: 'Hello from Lambda!',
+      inputEvent: event
+    }),
   };
   return response;
 };

--- a/templates/lambda/index.mjs
+++ b/templates/lambda/index.mjs
@@ -1,0 +1,8 @@
+export const handler = async (event) => {
+  console.log('Event: ', JSON.stringify(event, null, 2));
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({ hello: 'Hello from Lambda!' }),
+  };
+  return response;
+};

--- a/templates/lambda/package.json
+++ b/templates/lambda/package.json
@@ -2,8 +2,12 @@
   "name": "%PROJECT_NAME%",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "index.mjs",
   "scripts": {
+    "build:cleanup": "rm -f dist/index.js lambda.zip",
+    "build:bundle": "esbuild --bundle --outfile=./dist/index.js --platform=node --target=node22 ./index.mjs",
+    "build:zip": "zip -j lambda.zip dist/index.js",
+    "build": "pnpm build:cleanup && pnpm build:bundle && pnpm build:zip",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -11,6 +15,7 @@
   "license": "UNLICENSED",
   "type": "module",
   "devDependencies": {
+    "esbuild": "^0.25.5",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
This PR includes the following main changes:

- feat: add build scripts to the lambda template and a Managing lambdas with AWS CLI section to the readme
- docs: add more aws cli examples and rename lambda:remove to lambda:delete